### PR TITLE
Adding AI and spectator handoff control through Level

### DIFF
--- a/PythonAPI/examples/DReyeVR_AI.py
+++ b/PythonAPI/examples/DReyeVR_AI.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python
+
+import glob
+import os
+import sys
+import time
+
+try:
+    sys.path.append(
+        glob.glob(
+            "PythonAPI/carla/dist/carla-*%d.%d-%s.egg"
+            % (
+                sys.version_info.major,
+                sys.version_info.minor,
+                "win-amd64" if os.name == "nt" else "linux-x86_64",
+            )
+        )[0]
+    )
+except IndexError:
+    pass
+
+import carla
+
+import argparse
+from numpy import random
+
+
+def set_DReyeVR_autopilot(world, traffic_manager):
+    DReyeVR_vehicle = None
+    for actor in world.get_actors():
+        if "dreyevr" in actor.type_id.lower():
+            DReyeVR_vehicle = actor
+            break
+    if DReyeVR_vehicle is None:
+        print("Unable to find DReyeVR ego vehicle in world!")
+    else:
+        DReyeVR_vehicle.set_autopilot(True, traffic_manager.get_port())
+        print("Successfully set autopilot on ego vehicle")
+    return DReyeVR_vehicle
+
+
+def spawn_other_vehicles(max_vehicles, world, traffic_manager):
+    spawn_points = world.get_map().get_spawn_points()
+
+    blueprints = world.get_blueprint_library().filter("vehicle.*")
+    blueprints = sorted(blueprints, key=lambda bp: bp.id)
+
+    other_vehicles = []
+    for n, transform in enumerate(spawn_points):
+        if n >= max_vehicles:
+            break
+        blueprint = random.choice(blueprints)
+        if blueprint.has_attribute("color"):
+            color = random.choice(blueprint.get_attribute("color").recommended_values)
+            blueprint.set_attribute("color", color)
+        if blueprint.has_attribute("driver_id"):
+            driver_id = random.choice(
+                blueprint.get_attribute("driver_id").recommended_values
+            )
+            blueprint.set_attribute("driver_id", driver_id)
+        blueprint.set_attribute("role_name", "autopilot")
+
+        new_car = world.spawn_actor(blueprint, transform)
+        new_car.set_autopilot(True, traffic_manager.get_port())
+        other_vehicles.append(new_car)
+
+    print(f"successfully spawned {len(other_vehicles)} vehicles")
+    return other_vehicles
+
+
+def main():
+    argparser = argparse.ArgumentParser(description=__doc__)
+    argparser.add_argument(
+        "--host",
+        metavar="H",
+        default="127.0.0.1",
+        help="IP of the host server (default: 127.0.0.1)",
+    )
+    argparser.add_argument(
+        "-p",
+        "--port",
+        metavar="P",
+        default=2000,
+        type=int,
+        help="TCP port to listen to (default: 2000)",
+    )
+    argparser.add_argument(
+        "-n",
+        "--number-of-vehicles",
+        metavar="N",
+        default=10,
+        type=int,
+        help="number of vehicles (default: 10)",
+    )
+    argparser.add_argument(
+        "--tm-port",
+        metavar="P",
+        default=8000,
+        type=int,
+        help="port to communicate with TM (default: 8000)",
+    )
+    argparser.add_argument(
+        "-s", "--seed", metavar="S", type=int, help="Random device seed"
+    )
+    args = argparser.parse_args()
+
+    client = carla.Client(args.host, args.port)
+    client.set_timeout(10.0)
+    random.seed(args.seed if args.seed is not None else int(time.time()))
+
+    other_vehicles = []
+    try:
+        world = client.get_world()
+
+        traffic_manager = client.get_trafficmanager(args.tm_port)
+        traffic_manager.set_global_distance_to_leading_vehicle(1.0)
+        if args.seed is not None:
+            traffic_manager.set_random_device_seed(args.seed)
+
+        ego_vehicle = set_DReyeVR_autopilot(world, traffic_manager)
+
+        # spawn other vehicles
+        other_vehicles = spawn_other_vehicles(
+            args.number_of_vehicles, world, traffic_manager
+        )
+
+        while True:
+            world.wait_for_tick()
+    finally:
+
+        print("\ndestroying %d vehicles" % len(other_vehicles))
+        client.apply_batch([carla.command.DestroyActor(x.id) for x in other_vehicles])
+
+        time.sleep(0.5)
+
+
+if __name__ == "__main__":
+
+    try:
+        main()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        print("\ndone.")
+

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEpisode.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaEpisode.h
@@ -144,6 +144,11 @@ public:
     return ActorDispatcher->GetActorRegistry();
   }
 
+  FActorView RegisterActor(AActor &Actor, FActorDescription ActorDescription, FActorRegistry::IdType DesiredId = 0)
+  {
+    return ActorDispatcher->RegisterActor(Actor, ActorDescription, DesiredId);
+  }
+
   // ===========================================================================
   // -- Actor look up methods --------------------------------------------------
   // ===========================================================================

--- a/Unreal/CarlaUE4/Source/CarlaUE4/DReyeVR/DReyeVRInputs.cpp
+++ b/Unreal/CarlaUE4/Source/CarlaUE4/DReyeVR/DReyeVRInputs.cpp
@@ -1,0 +1,336 @@
+#include "EgoVehicle.h"
+
+// Called to bind functionality to input
+void AEgoVehicle::SetupPlayerInputComponent(UInputComponent *PlayerInputComponent)
+{
+    /// NOTE: to see all DReyeVR inputs see DefaultInput.ini
+    Super::SetupPlayerInputComponent(PlayerInputComponent);
+
+    /// NOTE: an Action is a digital input, an Axis is an analog input
+    // steering and throttle analog inputs (axes)
+    PlayerInputComponent->BindAxis("Steer_DReyeVR", this, &AEgoVehicle::SetSteering);
+    PlayerInputComponent->BindAxis("Throttle_DReyeVR", this, &AEgoVehicle::SetThrottle);
+    PlayerInputComponent->BindAxis("Brake_DReyeVR", this, &AEgoVehicle::SetBrake);
+    // reverse & handbrake actions
+    PlayerInputComponent->BindAction("ToggleReverse_DReyeVR", IE_Pressed, this, &AEgoVehicle::ToggleReverse);
+    PlayerInputComponent->BindAction("HoldHandbrake_DReyeVR", IE_Pressed, this, &AEgoVehicle::HoldHandbrake);
+    PlayerInputComponent->BindAction("HoldHandbrake_DReyeVR", IE_Released, this, &AEgoVehicle::ReleaseHandbrake);
+    PlayerInputComponent->BindAction("TurnSignalRight_DReyeVR", IE_Pressed, this, &AEgoVehicle::TurnSignalLeft);
+    PlayerInputComponent->BindAction("TurnSignalLeft_DReyeVR", IE_Pressed, this, &AEgoVehicle::TurnSignalRight);
+    /// Mouse X and Y input for looking up and turning
+    PlayerInputComponent->BindAxis("MouseLookUp_DReyeVR", this, &AEgoVehicle::MouseLookUp);
+    PlayerInputComponent->BindAxis("MouseTurn_DReyeVR", this, &AEgoVehicle::MouseTurn);
+    // Record button to log the EyeTracker data to the python client
+    PlayerInputComponent->BindAction("TogglePyRecord_DReyeVR", IE_Pressed, this, &AEgoVehicle::TogglePythonRecording);
+}
+
+void AEgoVehicle::CameraPositionAdjust(const FVector &displacement)
+{
+    const FVector &CurrRelLocation = this->GetVRCameraRoot()->GetRelativeLocation();
+    this->GetVRCameraRoot()->SetRelativeLocation(CurrRelLocation + displacement);
+}
+
+/// NOTE: the CarlaVehicle does not actually move the vehicle, only its state/animations
+// to actually move the vehicle we'll use GetVehicleMovementComponent() which is part of AWheeledVehicle
+void AEgoVehicle::SetSteering(const float SteeringInput)
+{
+    float SteeringDamping = 0.6f;
+    float ScaledSteeringInput = SteeringDamping * SteeringInput;
+    this->GetVehicleMovementComponent()->SetSteeringInput(ScaledSteeringInput); // UE4 control
+    // assign to input struct
+    VehicleInputs.Steering = ScaledSteeringInput;
+}
+
+void AEgoVehicle::SetThrottle(const float ThrottleInput)
+{
+    float ScaledThrottleInput = 1.0f * ThrottleInput;
+    this->GetVehicleMovementComponent()->SetThrottleInput(ScaledThrottleInput); // UE4 control
+
+    // apply new light state
+    FVehicleLightState Lights = this->GetVehicleLightState();
+    Lights.Reverse = false;
+    Lights.Brake = false;
+    this->SetVehicleLightState(Lights);
+
+    // assign to input struct
+    VehicleInputs.Throttle = ScaledThrottleInput;
+}
+
+void AEgoVehicle::SetBrake(const float BrakeInput)
+{
+    float ScaledBrakeInput = 2.0f * BrakeInput;
+    this->GetVehicleMovementComponent()->SetBrakeInput(ScaledBrakeInput); // UE4 control
+
+    // apply new light state
+    FVehicleLightState Lights = this->GetVehicleLightState();
+    Lights.Reverse = false;
+    Lights.Brake = true;
+    this->SetVehicleLightState(Lights);
+
+    // assign to input struct
+    VehicleInputs.Brake = ScaledBrakeInput;
+}
+
+void AEgoVehicle::ToggleReverse()
+{
+    // negate to toggle bw 1 (forwards) and -1 (backwards)
+    int NewGear = -1 * this->GetVehicleMovementComponent()->GetTargetGear();
+    bReverse = !bReverse;
+    this->GetVehicleMovementComponent()->SetTargetGear(NewGear, true); // UE4 control
+
+    // apply new light state
+    FVehicleLightState Lights = this->GetVehicleLightState();
+    Lights.Reverse = bReverse;
+    this->SetVehicleLightState(Lights);
+
+    UE_LOG(LogTemp, Log, TEXT("Toggle Reverse"));
+    // assign to input struct
+    VehicleInputs.ToggledReverse = true;
+
+    this->PlayGearShiftSound();
+}
+
+void AEgoVehicle::TurnSignalRight()
+{
+    // store in local input container
+    VehicleInputs.TurnSignalRight = true;
+
+    // apply new light state
+    FVehicleLightState Lights = this->GetVehicleLightState();
+    Lights.RightBlinker = true;
+    Lights.LeftBlinker = false;
+    this->SetVehicleLightState(Lights);
+
+    this->PlayTurnSignalSound();
+    RightSignalTimeToDie = FPlatformTime::Seconds() + 3.0f; // reset counter at 3s
+    LeftSignalTimeToDie = 0.f;                              // immediately stop left signal
+}
+
+void AEgoVehicle::TurnSignalLeft()
+{
+    // store in local input container
+    VehicleInputs.TurnSignalLeft = true;
+
+    // apply new light state
+    FVehicleLightState Lights = this->GetVehicleLightState();
+    Lights.RightBlinker = false;
+    Lights.LeftBlinker = true;
+    this->SetVehicleLightState(Lights);
+
+    this->PlayTurnSignalSound();
+    RightSignalTimeToDie = 0.f;                            // immediately stop right signal
+    LeftSignalTimeToDie = FPlatformTime::Seconds() + 3.0f; // reset counter at 3s
+}
+
+void AEgoVehicle::HoldHandbrake()
+{
+    this->GetVehicleMovementComponent()->SetHandbrakeInput(true); // UE4 control
+    // assign to input struct
+    VehicleInputs.HoldHandbrake = true;
+}
+
+void AEgoVehicle::ReleaseHandbrake()
+{
+    this->GetVehicleMovementComponent()->SetHandbrakeInput(false); // UE4 control
+    // assign to input struct
+    VehicleInputs.HoldHandbrake = false;
+}
+
+/// NOTE: in UE4 rotators are of the form: {Pitch, Yaw, Roll} (stored in degrees)
+/// We are basing the limits off of "Cervical Spine Functional Anatomy ad the Biomechanics of Injury":
+// "The cervical spine's range of motion is approximately 80° to 90° of flexion, 70° of extension,
+// 20° to 45° of lateral flexion, and up to 90° of rotation to both sides."
+// (www.ncbi.nlm.nih.gov/pmc/articles/PMC1250253/)
+/// NOTE: flexion = looking down to chest, extension = looking up , lateral = roll
+/// ALSO: These functions are only used in non-VR mode, in VR you can move freely
+
+void AEgoVehicle::MouseLookUp(const float mY_Input)
+{
+    if (mY_Input != 0.f)
+    {
+        const int ScaleY = InvertY ? 1 : -1; // negative Y is "normal" controls
+        FRotator UpDir = this->GetCamera()->GetRelativeRotation() + FRotator(ScaleY * mY_Input, 0.f, 0.f);
+        // get the limits of a human neck (only clamping pitch)
+        const float MinFlexion = -85.f;
+        const float MaxExtension = 70.f;
+        UpDir.Pitch = FMath::Clamp(UpDir.Pitch, MinFlexion, MaxExtension);
+        this->GetCamera()->SetRelativeRotation(UpDir);
+    }
+}
+
+void AEgoVehicle::MouseTurn(const float mX_Input)
+{
+    if (mX_Input != 0.f)
+    {
+        FRotator CurrentDir = this->GetCamera()->GetRelativeRotation();
+        FRotator TurnDir = CurrentDir + FRotator(0.f, mX_Input, 0.f);
+        // get the limits of a human neck (only clamping pitch)
+        const float MinLeft = -90.f;
+        const float MaxRight = 90.f; // may consider increasing to allow users to look through the back window
+        TurnDir.Yaw = FMath::Clamp(TurnDir.Yaw, MinLeft, MaxRight);
+        this->GetCamera()->SetRelativeRotation(TurnDir);
+    }
+}
+
+void AEgoVehicle::TogglePythonRecording()
+{
+    /// TODO: refactor
+    bool FoundSensor = false;
+    if (IsRecording)
+    {
+        UE_LOG(LogTemp, Log, TEXT("Ego-Vehicle stops logging"));
+        // if (EyeTrackerSensor)
+        //     FoundSensor = this->EyeTrackerSensor->ResetPyDReyeVRSensor();
+    }
+    else
+    {
+        UE_LOG(LogTemp, Log, TEXT("Ego-Vehicle starts logging"));
+        // if (EyeTrackerSensor)
+        //     FoundSensor = this->EyeTrackerSensor->FindPyDReyeVRSensor();
+    }
+    if (FoundSensor) // at least one is found in the Simulator (spawned)
+        IsRecording = !IsRecording;
+}
+
+#if USE_LOGITECH_WHEEL
+
+const std::vector<FString> VarNames = {"rgdwPOV[0]", "rgdwPOV[1]", "rgdwPOV[2]", "rgdwPOV[3]"};
+void AEgoVehicle::LogLogitechPluginStruct(const DIJOYSTATE2 *Now)
+{
+    if (Old == nullptr)
+    {
+        Old = new struct DIJOYSTATE2;
+        (*Old) = (*Now); // assign to the new (current) dijoystate struct
+        return;          // initializing the Old struct ptr
+    }
+    // Getting all (4) values from the current struct
+    const std::vector<int> NowVals = {int(Now->rgdwPOV[0]), int(Now->rgdwPOV[1]), int(Now->rgdwPOV[2]),
+                                      int(Now->rgdwPOV[3])};
+    // Getting the (4) values from the old struct
+    const std::vector<int> OldVals = {int(Old->rgdwPOV[0]), int(Old->rgdwPOV[1]), int(Old->rgdwPOV[2]),
+                                      int(Old->rgdwPOV[3])};
+
+    check(NowVals.size() == OldVals.size() && NowVals.size() == VarNames.size());
+
+    // print any differences
+    bool isDiff = false;
+    for (size_t i = 0; i < NowVals.size(); i++)
+    {
+        if (NowVals[i] != OldVals[i])
+        {
+            if (!isDiff) // only gets triggered at MOST once
+            {
+                UE_LOG(LogTemp, Log, TEXT("Logging joystick at t=%.3f"), UGameplayStatics::GetRealTimeSeconds(World));
+                isDiff = true;
+            }
+            UE_LOG(LogTemp, Log, TEXT("Triggered \"%s\" from %d to %d"), *(VarNames[i]), OldVals[i], NowVals[i]);
+        }
+    }
+
+    // also check the 128 rgbButtons array
+    for (size_t i = 0; i < 127; i++)
+    {
+        if (Old->rgbButtons[i] != Now->rgbButtons[i])
+        {
+            if (!isDiff) // only gets triggered at MOST once
+            {
+                UE_LOG(LogTemp, Log, TEXT("Logging joystick at t=%.3f"), UGameplayStatics::GetRealTimeSeconds(World));
+                isDiff = true;
+            }
+            UE_LOG(LogTemp, Log, TEXT("Triggered \"rgbButtons[%d]\" from %d to %d"), int(i), int(OldVals[i]),
+                   int(NowVals[i]));
+        }
+    }
+
+    // assign the current joystate into the old one
+    (*Old) = (*Now);
+}
+
+void AEgoVehicle::LogitechWheelUpdate()
+{
+    // only execute this in Windows, the Logitech plugin is incompatible with Linux
+    LogiUpdate(); // update the logitech wheel
+    DIJOYSTATE2 *WheelState = LogiGetState(0);
+    LogLogitechPluginStruct(WheelState);
+    /// NOTE: obtained these from LogitechWheelInputDevice.cpp:~111
+    // -32768 to 32767. -32768 = all the way to the left. 32767 = all the way to the right.
+    const float WheelRotation = FMath::Clamp(float(WheelState->lX), -32767.0f, 32767.0f) / 32767.0f; // (-1, 1)
+    // -32768 to 32767. 32767 = pedal not pressed. -32768 = pedal fully pressed.
+    const float AccelerationPedal = fabs(((WheelState->lY - 32767.0f) / (65535.0f))); // (0, 1)
+    // -32768 to 32767. Higher value = less pressure on brake pedal
+    const float BrakePedal = fabs(((WheelState->lRz - 32767.0f) / (65535.0f))); // (0, 1)
+    // -1 = not pressed. 0 = Top. 0.25 = Right. 0.5 = Bottom. 0.75 = Left.
+    const float Dpad = fabs(((WheelState->rgdwPOV[0] - 32767.0f) / (65535.0f)));
+    // apply to DReyeVR inputs
+    SetSteering(WheelRotation);
+    SetThrottle(AccelerationPedal);
+    SetBrake(BrakePedal);
+
+    //    UE_LOG(LogTemp, Log, TEXT("Dpad value %f"), Dpad);
+    //    if (WheelState->rgdwPOV[0] == 0) // should work now
+    if (WheelState->rgbButtons[0] || WheelState->rgbButtons[1] || WheelState->rgbButtons[2] ||
+        WheelState->rgbButtons[3]) // replace reverse with face buttons
+    {
+        if (isPressRisingEdgeRev == true) // only toggle reverse on rising edge of button press
+        {
+            isPressRisingEdgeRev = false; // not rising edge while the button is pressed
+            UE_LOG(LogTemp, Log, TEXT("Reversing: Dpad value %f"), Dpad);
+            ToggleReverse();
+        }
+    }
+    else
+    {
+        isPressRisingEdgeRev = true;
+    }
+    if (WheelState->rgbButtons[4])
+    {
+        TurnSignalRight();
+    }
+    if (WheelState->rgbButtons[5])
+    {
+        TurnSignalLeft();
+    }
+
+    // VRCamerRoot base position adjustment
+    if (WheelState->rgdwPOV[0] == 0) // positive in X
+        CameraPositionAdjust(FVector(1.f, 0.f, 0.f));
+    else if (WheelState->rgdwPOV[0] == 18000) // negative in X
+        CameraPositionAdjust(FVector(-1.f, 0.f, 0.f));
+    else if (WheelState->rgdwPOV[0] == 9000) // positive in Y
+        CameraPositionAdjust(FVector(0.f, 1.f, 0.f));
+    else if (WheelState->rgdwPOV[0] == 27000) // negative in Y
+        CameraPositionAdjust(FVector(0.f, -1.f, 0.f));
+    // VRCamerRoot base height adjustment
+    else if (WheelState->rgbButtons[19]) // positive in Z
+        CameraPositionAdjust(FVector(0.f, 0.f, 1.f));
+    else if (WheelState->rgbButtons[20]) // negative in Z
+        CameraPositionAdjust(FVector(0.f, 0.f, -1.f));
+}
+
+void AEgoVehicle::ApplyForceFeedback() const
+{
+    // only execute this in Windows, the Logitech plugin is incompatible with Linux
+    const float Speed = GetVelocity().Size(); // get magnitude of self (AActor's) velocity
+                                              //    UE_LOG(LogTemp, Log, TEXT("Speed value %f"), Speed);
+    const int WheelIndex = 0;                 // first (only) wheel attached
+    /// TODO: move outside this function (in tick()) to avoid redundancy
+    if (LogiHasForceFeedback(WheelIndex))
+    {
+        const int OffsetPercentage = 0;      // "Specifies the center of the spring force effect"
+        const int SaturationPercentage = 30; // "Level of saturation... comparable to a magnitude"
+        const int CoeffPercentage = 100; // "Slope of the effect strength increase relative to deflection from Offset"
+        LogiPlaySpringForce(WheelIndex, OffsetPercentage, SaturationPercentage, CoeffPercentage);
+    }
+    /// NOTE: there are other kinds of forces as described in the LogitechWheelPlugin API:
+    // https://github.com/drb1992/LogitechWheelPlugin/blob/master/LogitechWheelPlugin/Source/LogitechWheelPlugin/Private/LogitechBWheelInputDevice.cpp
+    // For example:
+    /*
+        Force Types
+        0 = Spring				5 = Dirt Road
+        1 = Constant			6 = Bumpy Road
+        2 = Damper				7 = Slippery Road
+        3 = Side Collision		8 = Surface Effect
+        4 = Frontal Collision	9 = Car Airborne
+    */
+}
+#endif

--- a/Unreal/CarlaUE4/Source/CarlaUE4/DReyeVR/DReyeVRLevel.h
+++ b/Unreal/CarlaUE4/Source/CarlaUE4/DReyeVR/DReyeVRLevel.h
@@ -6,6 +6,8 @@
 
 #include "DReyeVRLevel.generated.h"
 
+class AEgoVehicle;
+
 UCLASS()
 class ADReyeVRLevel : public ALevelScriptActor
 {
@@ -41,6 +43,12 @@ class ADReyeVRLevel : public ALevelScriptActor
     // Meta world functions
     void ToggleMute();
     void ToggleGazeHUD();
+    enum DRIVER
+    {
+        HUMAN,
+        SPECTATOR,
+        AI,
+    } ControlMode;
 
   private:
     // for handling inputs and possessions

--- a/Unreal/CarlaUE4/Source/CarlaUE4/DReyeVR/DReyeVRLevel.h
+++ b/Unreal/CarlaUE4/Source/CarlaUE4/DReyeVR/DReyeVRLevel.h
@@ -22,10 +22,13 @@ class ADReyeVRLevel : public ALevelScriptActor
 
     // input handling
     void SetupPlayerInputComponent();
+    void SetupSpectator();
+    bool FindEgoVehicle();
 
-    // util functions
     // EgoVehicle functions
-    void ToggleSpectator();
+    void PossessEgoVehicle();
+    void PossessSpectator();
+    void HandoffDriverToAI();
 
     // Recorder media functions
     void PlayPause();
@@ -42,10 +45,11 @@ class ADReyeVRLevel : public ALevelScriptActor
   private:
     // for handling inputs and possessions
     APlayerController *Player = nullptr;
+    AController *AI_Player = nullptr;
 
     // for toggling bw spectator mode
-    bool bIsSpectating = false;
-    ADReyeVRSpectator *SpectatorPtr = nullptr;
+    bool bIsSpectating = true;
+    APawn *SpectatorPtr = nullptr;
     AEgoVehicle *EgoVehiclePtr = nullptr;
 
     // for muting all the world sounds

--- a/Unreal/CarlaUE4/Source/CarlaUE4/DReyeVR/EgoVehicle.h
+++ b/Unreal/CarlaUE4/Source/CarlaUE4/DReyeVR/EgoVehicle.h
@@ -49,8 +49,16 @@ class CARLAUE4_API AEgoVehicle : public ACarlaWheeledVehicle
     FVector GetFPSPosn() const;
     FRotator GetFPSRot() const;
 
+    UCameraComponent *GetCamera();
+    const UCameraComponent *GetCamera() const;
+
+    const USceneComponent *GetVRCameraRoot() const;
+    USceneComponent *GetVRCameraRoot();
+
+    void PlayGearShiftSound(const float DelayBeforePlay = 0.f);
+    void PlayTurnSignalSound(const float DelayBeforePlay = 0.f);
+
     void ReplayUpdate();
-    void ToggleGazeHUD();
 
   protected:
     // Called when the game starts (spawned) or ends (destroyed)
@@ -58,8 +66,8 @@ class CARLAUE4_API AEgoVehicle : public ACarlaWheeledVehicle
     virtual void BeginDestroy() override;
 
     // World variables
-    UWorld *World;
-    APlayerController *Player;
+    class UWorld *World;
+    class APlayerController *Player;
 
     // For debug purposes
     void ErrMsg(const FString &message, const bool isFatal);
@@ -102,18 +110,6 @@ class CARLAUE4_API AEgoVehicle : public ACarlaWheeledVehicle
     void ReleaseHandbrake();
     void MouseLookUp(const float mY_Input);
     void MouseTurn(const float mX_Input);
-
-    // Vehicle Control Possession
-    enum Driver
-    {
-        HUMAN,
-        AI,
-        NONE,
-    } CurrentDriver;
-    void HandoffToHuman();
-    void HandoffToAI();
-    void HandoffToNone();
-    void DriverHandoff(const Driver NewDriver);
 
 #if USE_LOGITECH_WHEEL
     DIJOYSTATE2 *Old = nullptr; // global "old" struct for the last state
@@ -181,10 +177,9 @@ class CARLAUE4_API AEgoVehicle : public ACarlaWheeledVehicle
     // Audio components
     void InitDReyeVRSounds();
     // void SoundUpdate(); // handled in parent class (with Engine rev)
-    void SetVolume(const float Mult) override; // allow us to mute all our extra sounds (gear/signals)
-    class UAudioComponent *GearShiftSound;     // nice for toggling reverse
-    class UAudioComponent *TurnSignalSound;    // good for turn signals
-    class UAudioComponent *CrashSound;         // crashing with another actor
+    class UAudioComponent *GearShiftSound;  // nice for toggling reverse
+    class UAudioComponent *TurnSignalSound; // good for turn signals
+    class UAudioComponent *CrashSound;      // crashing with another actor
 
     // Eye gaze variables
     bool bDrawDebugEditor = false;

--- a/Unreal/CarlaUE4/Source/CarlaUE4/DReyeVR/EgoVehicle.h
+++ b/Unreal/CarlaUE4/Source/CarlaUE4/DReyeVR/EgoVehicle.h
@@ -8,6 +8,7 @@
 #include "Components/SceneComponent.h"            // USceneComponent
 #include "CoreMinimal.h"                          // Unreal functions
 #include "DReyeVRHUD.h"                           // ADReyeVRHUD
+#include "DReyeVRLevel.h"                         // ADReyeVRLevel
 #include "DReyeVRUtils.h"                         // ReadConfigValue
 #include "EyeTracker.h"                           // AEyeTracker
 #include "ImageUtils.h"                           // CreateTexture2D
@@ -29,6 +30,8 @@
 
 #include "EgoVehicle.generated.h"
 
+class ADReyeVRLevel;
+
 UCLASS()
 class CARLAUE4_API AEgoVehicle : public ACarlaWheeledVehicle
 {
@@ -43,11 +46,13 @@ class CARLAUE4_API AEgoVehicle : public ACarlaWheeledVehicle
 
     // Called to bind functionality to input
     virtual void SetupPlayerInputComponent(class UInputComponent *PlayerInputComponent) override;
+    void SetLevel(ADReyeVRLevel *Level);
 
     FVector GetCameraOffset() const;
 
-    FVector GetFPSPosn() const;
-    FRotator GetFPSRot() const;
+    FVector GetCameraPosn() const;
+    FVector GetNextCameraPosn(const float DeltaTime) const;
+    FRotator GetCameraRot() const;
 
     UCameraComponent *GetCamera();
     const UCameraComponent *GetCamera() const;
@@ -68,6 +73,10 @@ class CARLAUE4_API AEgoVehicle : public ACarlaWheeledVehicle
     // World variables
     class UWorld *World;
     class APlayerController *Player;
+
+    // Level variables
+    void TickLevel(float DeltaSeconds);
+    ADReyeVRLevel *DReyeVRLevel = nullptr;
 
     // For debug purposes
     void ErrMsg(const FString &message, const bool isFatal);


### PR DESCRIPTION
Things that changed:
- Refactored DReyeVRLevel
- Using default Spectator
- Added Actor Registration from cpp (for PythonAPI to see our EgoVehicle as a vehicle)
- Have camera follow AI controller when taking over EgoVehicle
- Moved EgoVehicle input impl into DReyeVRInputs.cpp
- Removed some vestigial functions like ToggleGazeHUD and PythonRecording

TODO:
- Verify PythonAPI still is fully compatible with these changes
- See if Recorder respects AI controller
- have a way for a participant (ie. default PlayerController) can signal to the Level to switch handoff control on demand